### PR TITLE
Add --no-drop-tables option

### DIFF
--- a/lib/mosql/cli.rb
+++ b/lib/mosql/cli.rb
@@ -86,6 +86,10 @@ module MoSQL
         opts.on("--reimport", "Force a data re-import") do
           @options[:reimport] = true
         end
+
+        opts.on("--no-drop-tables", "Don't drop the table if it exists during the initial import") do
+          @options[:no_drop_tables] = true
+        end
       end
 
       optparse.parse!(@args)
@@ -183,7 +187,7 @@ module MoSQL
     end
 
     def initial_import
-      @schemamap.create_schema(@sql.db, true)
+      @schemamap.create_schema(@sql.db, !options[:no_drop_tables])
 
       start_ts = @mongo['local']['oplog.rs'].find_one({}, {:sort => [['$natural', -1]]})['ts']
 
@@ -207,7 +211,7 @@ module MoSQL
       count = 0
       batch = []
       table = @sql.table_for_ns(ns)
-      table.truncate
+      table.truncate unless options[:no_drop_tables]
 
       start    = Time.now
       sql_time = 0


### PR DESCRIPTION
This allows multiple MoSQL clients to run against different Mongo shards without destroying the contents of the table(s) when each one is initialized.

I also missed something in my original commit that I only found going back to do this, so it was a good thing I did.
