### PR TITLE
Extract ObjectId from DBRef arrays

### DIFF
--- a/lib/mosql/schema.rb
+++ b/lib/mosql/schema.rb
@@ -181,6 +181,7 @@ module MoSQL
           when Hash
             v = JSON.dump(v)
           when Array
+            v.map! {|item| item.is_a?(BSON::DBRef) ? item.object_id.to_s : item}
             if col[:array_type]
               v = Sequel.pg_array(v, col[:array_type])
             else

--- a/test/unit/lib/mosql/schema.rb
+++ b/test/unit/lib/mosql/schema.rb
@@ -177,6 +177,13 @@ EOF
       assert_equal(["row 1", nil, oid.to_s, nil], out)
     end
 
+    it 'converts DBRef to object id in arrays' do
+      oid = [ BSON::ObjectId.new, BSON::ObjectId.new]
+      o = {'_id' => "row 1", "str" => [ BSON::DBRef.new('db.otherns', oid[0]), BSON::DBRef.new('db.otherns', oid[1]) ] }
+      out = @map.transform('db.collection', o)
+      assert_equal(["row 1", nil, JSON.dump(oid.map! {|o| o.to_s}), nil ], out)
+    end
+
     it 'changes NaN to null in extra_props' do
       out = @map.transform('db.with_extra_props', {'_id' => 7, 'nancy' => 0.0/0.0})
       extra = JSON.parse(out[1])


### PR DESCRIPTION
Since issue #50 was closed with commit 8043b96, I'd like to try contributing.

When an Array contains DBRef objects, it's best to use the $oid BSON::ObjectId  string value instead of the default string representation of DBRef which is not a valid hash. This is consistent with the conversion made for single DBRef values. This has been tested with both JSON and TEXT ARRAY columns types.
