### PR TITLE
support applyOps in the oplog

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,16 @@ Patches and contributions are welcome! Please fork the project and
 open a pull request on [github][github], or just report issues.
 
 MoSQL includes a small but hopefully-growing test suite. It assumes a
-running PostgreSQL and MongoDB instance on the local host; You can
-point it at a different target via environment variables; See
-`test/functional/_lib.rb` for more information.
+running PostgreSQL and MongoDB instance on the local host. To run the
+test suite, first install all of MoSQL's dependencies:
+```shell
+bundle install
+```
+Then, run the tests:
+```shell
+rake test
+```
+You can also point the suite at a different target via environment
+variables; See `test/functional/_lib.rb` for more information.
 
 [github]: https://github.com/stripe/mosql

--- a/lib/mosql/streamer.rb
+++ b/lib/mosql/streamer.rb
@@ -199,6 +199,15 @@ module MoSQL
         return
       end
 
+      # First, check if this was an operation performed via applyOps. If so, call handle_op with
+      # for each op that was applied.
+      # The oplog format of applyOps commands can be viewed here:
+      # https://groups.google.com/forum/#!topic/mongodb-user/dTf5VEJJWvY
+      if op['op'] == 'c' && (ops = op['o']['applyOps'])
+        ops.each { |op| handle_op(op) }
+        return
+      end
+
       unless @schema.find_ns(op['ns'])
         log.debug("Skipping op for unknown ns #{op['ns']}...")
         return

--- a/test/functional/streamer.rb
+++ b/test/functional/streamer.rb
@@ -95,6 +95,22 @@ EOF
       assert_equal(27, sequel[:sqltable].where(:_id => o['_id'].to_s).select.first[:var])
     end
 
+    it 'applies ops performed via applyOps' do
+      o = { '_id' => BSON::ObjectId.new, 'var' => 17 }
+      @adapter.upsert_ns('mosql_test.collection', o)
+
+      op = { 'ns' => 'mosql_test.collection',
+             'op' => 'u',
+             'o2' => { '_id' => o['_id'] },
+             'o'  => { 'var' => 27 }
+           }
+      @streamer.handle_op({ 'op' => 'c',
+                            'ns' => 'mosql_test.$cmd',
+                            'o' => { 'applyOps' => [op] }
+                          })
+      assert_equal(27, sequel[:sqltable].where(:_id => o['_id'].to_s).select.first[:var])
+    end
+
     it 'handle "d" ops with BSON::ObjectIds' do
       o = { '_id' => BSON::ObjectId.new, 'var' => 17 }
       @adapter.upsert_ns('mosql_test.collection', o)


### PR DESCRIPTION
Mongo has a command called [applyOps](http://docs.mongodb.org/manual/reference/command/applyOps/) that lets you apply an array of oplog entries to a mongod instance. When we used this, we noticed that MoSQL wasn't replicating these operations properly. We looked into it and it turns out that [oplog entries from applyOps aren't formatted like normal oplog entries](https://groups.google.com/forum/#!topic/mongodb-user/dTf5VEJJWvY).

This change allows MoSQL to handle oplog entries from applyOps easily by calling `handle_op` for each operation in the array.
