### PR TITLE
convert binary data to hex.  fixes #64.

### DIFF
--- a/lib/mosql/schema.rb
+++ b/lib/mosql/schema.rb
@@ -181,7 +181,7 @@ module MoSQL
           v = fetch_and_delete_dotted(obj, source)
           case v
           when BSON::Binary, BSON::ObjectId, Symbol
-            v = v.to_s
+            v = v.to_s.unpack("H*")
           when BSON::DBRef
             v = v.object_id.to_s
           when Hash


### PR DESCRIPTION
Fixes UTF8 errors by encoding binary data in hex.

```
PG::CharacterNotInRepertoire: ERROR:  invalid byte sequence
 for encoding "UTF8": 0xaf (Sequel::DatabaseError)
```

Note, `BSON::DBRef` may need a similar treatment in lines 186 and 190?
#### Verification:

I have used this to import UUID from mongo to postgresql

``` javascript
> db.entities.findOne();
{
        "_id" : BinData(3,"DHSvnWWKRQ6hydIk/B4RaQ=="),
        "slug" : "DHSvnWWKRQ6hydIk_B4RaQ"
}
```

collections.yml:

``` yaml
    db2:
      entities:
        :columns:
        - id:
          :source: _id
          :type: UUID
        - slug: TEXT
        :meta:
          :table: entities
          :extra_props: false
```

``` sql
vagrant=# select * from entities where slug='DHSvnWWKRQ6hydIk_B4RaQ'
;
                  id                  |          slug
--------------------------------------+------------------------
 0c74af9d-658a-450e-a1c9-d224fc1e1169 | DHSvnWWKRQ6hydIk_B4RaQ
(1 row)
```
