### PR TITLE
Batch inserts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: .
   specs:
-    mosql (0.4.0)
+    mosql (0.5.0)
       bson_ext
       json
       log4r
       mongo
-      mongoriver (= 0.4)
+      mongoriver (= 0.4.2)
       pg
       rake
       sequel
@@ -14,18 +14,18 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    bson (1.10.2)
-    bson_ext (1.10.2)
-      bson (~> 1.10.2)
+    bson (1.11.1)
+    bson_ext (1.11.1)
+      bson (~> 1.11.1)
     json (1.8.1)
     log4r (1.1.10)
     metaclass (0.0.4)
     minitest (3.0.0)
     mocha (1.0.0)
       metaclass (~> 0.0.1)
-    mongo (1.10.2)
-      bson (= 1.10.2)
-    mongoriver (0.4.0)
+    mongo (1.11.1)
+      bson (= 1.11.1)
+    mongoriver (0.4.2)
       bson_ext
       log4r
       mongo (>= 1.7)

--- a/lib/mosql/version.rb
+++ b/lib/mosql/version.rb
@@ -1,3 +1,3 @@
 module MoSQL
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/mosql.gemspec
+++ b/mosql.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   %w[sequel pg mongo bson_ext rake log4r json
      ].each { |dep| gem.add_runtime_dependency(dep) }
-  gem.add_runtime_dependency "mongoriver", "0.4"
+  gem.add_runtime_dependency "mongoriver", "0.4.2"
 
   gem.add_development_dependency "minitest"
   gem.add_development_dependency "mocha"

--- a/test/functional/streamer.rb
+++ b/test/functional/streamer.rb
@@ -365,6 +365,7 @@ EOF
           "ns" => "db.has_timestamp",
           "o"  => mongo['db']['has_timestamp'].find_one({_id: id})
         })
+      @streamer.do_batch_inserts
       got = @sequel[:has_timestamp].where(:_id => id.to_s).select.first[:ts]
       assert_equal(ts.to_i, got.to_i)
       assert_equal(ts.tv_usec, got.tv_usec)

--- a/test/functional/transform.rb
+++ b/test/functional/transform.rb
@@ -114,6 +114,7 @@ class MoSQL::Test::Functional::TransformTest < MoSQL::Test::Functional
           "ns" => "test.test_transform",
           "o"  => collection.find_one(_id: id)
         })
+      streamer.do_batch_inserts
 
       got = @sequel[:test_transform].where(_id: id).to_a
       assert_equal(sql, got.first[:value], "was able to transform a #{typ} field while streaming")


### PR DESCRIPTION
This pull request adds support for batching sequential INSERTs when doing tailing, speeding up tailing under certain conditions while not being slower than the current state. See also issue #47.

r? @nelhage 
cc @snoble 

Basic strategy is to batch consecutive inserts together per namespace. Batch gets saved whenever:
- An update or delete is done to the same namespace as the insert
- After streaming (up to) 1000 updates from oplog, time from last batch update is larger than 5 seconds.
- More than a threshold of updates have happened in this namespace.
- Program is exiting/streaming stops.

Some handwavy measurements for tailing 20000 oplog entries:
- Speed is roughly the same on current master and this when alternating between doing inserts and updates. (~350s on local machine)
- 10 inserts per update: ~4.6x faster (76s on local machine)
- 20 inserts per update: ~7.4x faster (47s)
- 50 inserts per update: ~11x faster (32s)
- 1000 inserts per update: ~31x faster (~11.1s, though probably running into measurement overhead here)

---

Notes on potential future work (That I may or may not be working on soonish):

The next "low hanging" performance fruit to work on after this would be to optimize updates, though this wouldn't have this large of an effect. 

Some ideas on how can be done: `$set` entries in oplog can directly be translated into postgres queries only updating those columns mentioned. Updates without `$set` can replace the current row in postgres with the data in oplog entry. Tricky part here is figuring out if/how this applies to tokumx even after mongoriver does oplog entry translation (if they support any other $ operations) and unset.

Another performance improvement would be to have multiple tailers in either separate threads or processes, separated by namespace. This would however keeping multiple tailing states in database (one per namespace) and I'm not quite sure what the performance implications are for mongo for querying the same oplog (with filters?) from multiple processes.
