### PR TITLE
Support boolean source '$exists foo.bar.baz'

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     mosql (0.4.0)
+      bson (~> 1.10.2)
       bson_ext
       json
       log4r

--- a/mosql.gemspec
+++ b/mosql.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   %w[sequel pg mongo bson_ext rake log4r json
      ].each { |dep| gem.add_runtime_dependency(dep) }
   gem.add_runtime_dependency "mongoriver", "0.4"
+  gem.add_runtime_dependency "bson", "~> 1.10.2"
 
   gem.add_development_dependency "minitest"
   gem.add_development_dependency "mocha"

--- a/test/functional/streamer.rb
+++ b/test/functional/streamer.rb
@@ -262,7 +262,7 @@ EOF
             @streamer.handle_op({ 'ns' => 'mosql_test.collection',
                                   'op' => 'u',
                                   'o2' => { '_id' => 'a' },
-                                  'o'  => { 'var' => 1 << 70 },
+                                  'o'  => { 'var' => 1 << 62 },
                                 })
           end
         end
@@ -272,7 +272,7 @@ EOF
           @streamer.handle_op({ 'ns' => 'mosql_test.collection',
                                 'op' => 'u',
                                 'o2' => { '_id' => 'a' },
-                                'o'  => { 'var' => 1 << 70 },
+                                'o'  => { 'var' => 1 << 62 },
                               })
           assert_equal(0, sequel[:sqltable].where(:_id => 'a').count)
         end


### PR DESCRIPTION
The seemingly unrelated test change is to prevent an exception in
BSON.serialize.
