### PR TITLE
Allow specifying an oplog filter

### DIFF
--- a/lib/mosql/cli.rb
+++ b/lib/mosql/cli.rb
@@ -98,6 +98,11 @@ module MoSQL
         opts.on("--unsafe", "Ignore rows that cause errors on insert") do
           @options[:unsafe] = true
         end
+
+        # eg, --oplog-filter '{"ns": {"$regex": "^somedb[0-9]*\\.collection$"}}'
+        opts.on("--oplog-filter [filter]", "An additional JSON filter for the oplog query") do |filter|
+          @options[:oplog_filter] = JSON.parse(filter)
+        end
       end
 
       optparse.parse!(@args)

--- a/lib/mosql/streamer.rb
+++ b/lib/mosql/streamer.rb
@@ -170,7 +170,7 @@ module MoSQL
       if tail_from.is_a? Time
         tail_from = tailer.most_recent_position(tail_from)
       end
-      tailer.tail(:from => tail_from)
+      tailer.tail(:from => tail_from, :filter => options[:oplog_filter])
       until @done
         tailer.stream(1000) do |op|
           handle_op(op)


### PR DESCRIPTION
This allows you to reduce bandwidth between Mongo and mosql if you're
only copying a subset of the database.

No test because there doesn't appear to be any pre-existing tests of optail...
