### PR TITLE
GridFS support

### DIFF
--- a/lib/mosql.rb
+++ b/lib/mosql.rb
@@ -3,6 +3,7 @@ require 'mongo'
 require 'sequel'
 require 'mongoriver'
 require 'json'
+require 'pg'
 
 require 'mosql/version'
 require 'mosql/log'

--- a/lib/mosql/schema.rb
+++ b/lib/mosql/schema.rb
@@ -177,7 +177,7 @@ module MoSQL
       obj.has_key?(pieces.first)
     end
 
-    def fetch_special_source(obj, source, original)
+    def fetch_special_source(ns, obj, source, original)
       case source
       when "$timestamp"
         Sequel.function(:now)
@@ -229,7 +229,7 @@ module MoSQL
         type = col[:type]
 
         if source.start_with?("$")
-          v = fetch_special_source(obj, source, original)
+          v = fetch_special_source(ns, obj, source, original)
         else
           v = fetch_and_delete_dotted(obj, source)
           case v

--- a/lib/mosql/schema.rb
+++ b/lib/mosql/schema.rb
@@ -57,8 +57,13 @@ module MoSQL
       meta
     end
 
+    def set_gridfs(db)
+      @gridfs = Mongo::Grid.new(db)
+    end
+
     def initialize(map)
       @map = {}
+      @gridfs = nil
       map.each do |dbname, db|
         @map[dbname] = { :meta => parse_meta(db[:meta]) }
         db.each do |cname, spec|
@@ -176,6 +181,12 @@ module MoSQL
       case source
       when "$timestamp"
         Sequel.function(:now)
+      when "$data"
+        dbname, collection = ns.split(".", 2)
+        if collection == 'fs.files'
+          file = @gridfs.get(original["_id"])
+          Sequel::SQL::Blob.new(file.read)
+        end
       when /^\$exists (.+)/
         # We need to look in the cloned original object, not in the version that
         # has had some fields deleted.
@@ -318,7 +329,8 @@ module MoSQL
       when DateTime, Time
         val.strftime("%FT%T.%6N %z")
       when Sequel::SQL::Blob
-        "\\\\x" + [val].pack("h*")
+        # "\\\\x" + [val].pack("h*") # Don't know how this affects other use cases...
+        PG::Connection.escape_bytea(val)
       else
         val.to_s.gsub(/([\\\t\n\r])/, '\\\\\\1')
       end

--- a/lib/mosql/streamer.rb
+++ b/lib/mosql/streamer.rb
@@ -115,6 +115,7 @@ module MoSQL
 
         log.info("Importing for Mongo DB #{dbname}...")
         db = @mongo.db(dbname)
+        @schema.set_gridfs(db)
         collections = db.collections.select { |c| spec.key?(c.name) }
 
         collections.each do |collection|


### PR DESCRIPTION
This is for #90, Adding gridfs support.

Sorry i'm not a ruby dev so maybe there's some better way to handle this.
I found Sequel couldn't properly use encode_bytea (which is what was needed to get around encoding issues mentioned in the issue ticket), so added in pg as a requirement for that, if you'd like to reduce dependencies you should find how to get Sequel to offer encode_bytea as a class method, I could only get it to work as an instance method by passing the pg object down 

Also didn't have time to write tests (aside from finally successfully loading my gridfs store, which houses pdfs/ word docs/ images/ plaintext/etc) also i'm not overly used to ruby's test's.
I did /run/ the current tests and all but one passed (for $timestamp, but it was failing on master also so i'm gonna say not caused by this)  
