### PR TITLE
Feature/fix cursor timeout

### DIFF
--- a/lib/mosql/streamer.rb
+++ b/lib/mosql/streamer.rb
@@ -142,20 +142,18 @@ module MoSQL
       start    = Time.now
       sql_time = 0
       collection.find(filter, :timeout => false, :batch_size => BATCH) do |cursor|
-        with_retries do
-          cursor.each do |obj|
-            batch << @schema.transform(ns, obj)
-            count += 1
+        cursor.each do |obj|
+          batch << @schema.transform(ns, obj)
+          count += 1
 
-            if batch.length >= BATCH
-              sql_time += track_time do
-                bulk_upsert(table, ns, batch)
-              end
-              elapsed = Time.now - start
-              log.info("Imported #{count} rows (#{elapsed}s, #{sql_time}s SQL)...")
-              batch.clear
-              exit(0) if @done
+          if batch.length >= BATCH
+            sql_time += track_time do
+              bulk_upsert(table, ns, batch)
             end
+            elapsed = Time.now - start
+            log.info("Imported #{count} rows (#{elapsed}s, #{sql_time}s SQL)...")
+            batch.clear
+            exit(0) if @done
           end
         end
       end

--- a/lib/mosql/streamer.rb
+++ b/lib/mosql/streamer.rb
@@ -141,7 +141,7 @@ module MoSQL
 
       start    = Time.now
       sql_time = 0
-      collection.find(filter, :batch_size => BATCH) do |cursor|
+      collection.find(filter, :timeout => false, :batch_size => BATCH) do |cursor|
         with_retries do
           cursor.each do |obj|
             batch << @schema.transform(ns, obj)


### PR DESCRIPTION
This is a weird one; we have a collection with 51 million records that we need to mirror to postgres and we kept hitting the CURSOR_NOT_FOUND exception.  As recommended on https://github.com/mongodb/mongo-ruby-driver/wiki/FAQ#i-keep-getting-cursor_not_found-exceptions-whats-happening I tried adding the `:timeout => false` parameter, which did not change anything.  However, once I additionally removed the "with_retries" around it everything works.  I don't know why that would break it, I'm not much of a ruby guy, but it doesn't seem to be doing anything near as important as getting all entries in a large collection, so unless you have a suggestion for another way to fix this I suggest this fix.
