### PR TITLE
Feature: define ignored PostgreSQL fields by using `__ignore__` as source

### DIFF
--- a/lib/mosql/schema.rb
+++ b/lib/mosql/schema.rb
@@ -12,7 +12,7 @@ module MoSQL
           col = {
             :source => ent.fetch(:source),
             :type   => ent.fetch(:type),
-            :name   => (ent.keys - [:source, :type]).first,
+            :name   => (ent.keys - [:source, :type]).first
           }
         elsif ent.is_a?(Hash) && ent.keys.length == 1 && ent.values.first.is_a?(String)
           col = {
@@ -217,8 +217,11 @@ module MoSQL
         source = col[:source]
         type = col[:type]
 
-        if source.start_with?("$")
+        if source == '__ignore__'
+          # Just ignore the field
+        elsif source.start_with?("$")
           v = fetch_special_source(obj, source, original)
+          row << v
         else
           v = fetch_and_delete_dotted(obj, source)
           case v
@@ -234,8 +237,8 @@ module MoSQL
           else
             v = transform_primitive(v, type)
           end
+          row << v
         end
-        row << v
       end
 
       if schema[:meta][:extra_props]
@@ -269,7 +272,7 @@ module MoSQL
     end
 
     def copy_column?(col)
-      col[:source] != '$timestamp'
+      col[:source] != '$timestamp' && col[:source] != '__ignore__'
     end
 
     def all_columns(schema, copy=false)

--- a/lib/mosql/schema.rb
+++ b/lib/mosql/schema.rb
@@ -323,7 +323,7 @@ module MoSQL
       when Sequel::SQL::Blob
         "\\\\x" + [val].pack("h*")
       else
-        val.to_s.gsub(/([\\\t\n\r])/, '\\\\\\1')
+        val.to_s.encode!('UTF-8', :undef => :replace, :invalid => :replace).gsub(/([\\\t\n\r])/, '\\\\\\1')
       end
     end
 

--- a/lib/mosql/streamer.rb
+++ b/lib/mosql/streamer.rb
@@ -52,8 +52,8 @@ module MoSQL
       begin
         @schema.copy_data(table.db, ns, items)
       rescue Sequel::DatabaseError => e
-        log.debug("Bulk insert error (#{e}), attempting invidual upserts...")
-        cols = @schema.all_columns(@schema.find_ns(ns))
+        log.debug("Bulk insert error (#{e}), attempting individual upserts...")
+        cols = @schema.all_columns_for_copy(@schema.find_ns(ns))
         items.each do |it|
           h = {}
           cols.zip(it).each { |k,v| h[k] = v }


### PR DESCRIPTION
One of the issues we came across was trying to create a SERIAL primary key in PostgreSQL that won't be copied and should not be inserted as NULL while copying from MongoDB.
This hack allows this behavior using a magical string `__ignore__`.
