### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ have access to the oplog.
 If you need to force a fresh reimport, run `--reimport`, which will
 cause `mosql` to drop tables, create them anew, and do another import.
 
-Normaly, MoSQL will scan through a list of the databases on the mongo
-server you connect to. You avoid this behavior by specifiying a specific
+Normally, MoSQL will scan through a list of the databases on the mongo
+server you connect to. You avoid this behavior by specifying a specific
 mongo db to connect to with the `--only-db [dbname]` option. This is
 useful for hosted services which do not let you list all databases (via
 the `listDatabases` command).


### PR DESCRIPTION
Found some spelling mistakes -
`Normaly` > `Normally`
`specifiying` > `specifying`
