### PR TITLE
Mosql timeout

### DIFF
--- a/lib/mosql/cli.rb
+++ b/lib/mosql/cli.rb
@@ -107,6 +107,11 @@ module MoSQL
         opts.on("--oplog-filter [filter]", "An additional JSON filter for the oplog query") do |filter|
           @options[:oplog_filter] = JSON.parse(filter)
         end
+
+        #Configurable timeout field to override the default of 20 seconds
+        opts.on("--socket-timeout", "Set the timeout for reads from MongoDB") do |timeout|
+          @options[:op_timeout] = timeout
+        end
       end
 
       optparse.parse!(@args)
@@ -121,7 +126,7 @@ module MoSQL
     end
 
     def connect_mongo
-      @mongo = Mongo::MongoClient.from_uri(options[:mongo])
+      @mongo = Mongo::MongoClient.from_uri(options[:mongo], op_timeout: options[:op_timeout])
       config = @mongo['admin'].command(:ismaster => 1)
       if !config['setName'] && !options[:skip_tail]
         log.warn("`#{options[:mongo]}' is not a replset.")

--- a/lib/mosql/cli.rb
+++ b/lib/mosql/cli.rb
@@ -109,8 +109,8 @@ module MoSQL
         end
 
         #Configurable timeout field to override the default of 20 seconds
-        opts.on("--socket-timeout", "Set the timeout for reads from MongoDB") do |timeout|
-          @options[:op_timeout] = timeout
+        opts.on("--socket-timeout [timeout]", "Set the timeout for reads from MongoDB") do |timeout|
+          @options[:op_timeout] = timeout.to_i
         end
       end
 

--- a/lib/mosql/schema.rb
+++ b/lib/mosql/schema.rb
@@ -190,7 +190,7 @@ module MoSQL
       when BSON::ObjectId, Symbol
         v.to_s
       when BSON::Binary
-        if type.downcase == 'uuid'
+        if type && type.downcase == 'uuid'
           v.to_s.unpack("H*").first
         else
           Sequel::SQL::Blob.new(v.to_s)

--- a/lib/mosql/streamer.rb
+++ b/lib/mosql/streamer.rb
@@ -73,7 +73,7 @@ module MoSQL
           raise if e.kind_of?(Mongo::OperationFailure) && [11000, 11001].include?(e.error_code)
           # Cursor timeout
           raise if e.kind_of?(Mongo::OperationFailure) && e.message =~ /^Query response returned CURSOR_NOT_FOUND/
-          delay = 0.5 * (1.5 ** try)
+          delay = 0.5 * (2 ** try)
           log.warn("Mongo exception: #{e}, sleeping #{delay}s...")
           sleep(delay)
         end


### PR DESCRIPTION
-Added a command line option to set Mongo socket timeout.
-Slightly increased the delay between Mongo retries
-Wrapped the oplog updates in a retry block with maximum of three retries and 30 mins of delay. 
