### PR TITLE
ssl compatibility

### DIFF
--- a/lib/mosql/cli.rb
+++ b/lib/mosql/cli.rb
@@ -121,7 +121,7 @@ module MoSQL
     end
 
     def connect_mongo
-      @mongo = Mongo::MongoClient.from_uri(options[:mongo])
+      @mongo = Mongo::MongoClient.from_uri(options[:mongo], ssl_opts(options[:mongo]))
       config = @mongo['admin'].command(:ismaster => 1)
       if !config['setName'] && !options[:skip_tail]
         log.warn("`#{options[:mongo]}' is not a replset.")
@@ -175,6 +175,12 @@ module MoSQL
       unless options[:skip_tail]
         @streamer.optail
       end
+    end
+
+    private
+  
+    def ssl_opts(uri)
+      options[:mongo].match /ssl=true/ ? {ssl: true, ssl_verify: false} : {}
     end
   end
 end

--- a/lib/mosql/version.rb
+++ b/lib/mosql/version.rb
@@ -1,3 +1,3 @@
 module MoSQL
-  VERSION = "0.4.3"
+  VERSION = "0.4.4"
 end


### PR DESCRIPTION
My company just used MoSQL to migrate our production MongoDB into Postgres but we needed it to support SSL for Compose.io, which it didn't seem to handle yet.  Hopefully, this may be helpful for others trying to use this project in the future.

