### PR TITLE
Support more advanced schemas, including foreign keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 collections.yml
 /.bundle/
 Gemfile.lock
+vendor

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+scriptdir=$(python -c "import os; print(os.path.realpath('$(dirname $0)'))")
+rootdir=$scriptdir/../
+
+export RUBYLIB=$rootdir/lib:$RUBYLIB
+exec $rootdir/bin/mosql "$@"

--- a/lib/mosql/cli.rb
+++ b/lib/mosql/cli.rb
@@ -26,7 +26,6 @@ module MoSQL
     def setup_signal_handlers
       %w[TERM INT USR2].each do |sig|
         Signal.trap(sig) do
-          log.info("Got SIG#{sig}. Preparing to exit...")
           @streamer.stop
         end
       end

--- a/lib/mosql/cli.rb
+++ b/lib/mosql/cli.rb
@@ -121,7 +121,7 @@ module MoSQL
     end
 
     def connect_mongo
-      @mongo = Mongo::MongoClient.from_uri(options[:mongo])
+      @mongo = Mongo::MongoClient.from_uri(options[:mongo], :pool_size => 8)
       config = @mongo['admin'].command(:ismaster => 1)
       if !config['setName'] && !options[:skip_tail]
         log.warn("`#{options[:mongo]}' is not a replset.")

--- a/lib/mosql/cli.rb
+++ b/lib/mosql/cli.rb
@@ -26,6 +26,7 @@ module MoSQL
     def setup_signal_handlers
       %w[TERM INT USR2].each do |sig|
         Signal.trap(sig) do
+          puts("Got SIG#{sig}. Preparing to exit...")
           @streamer.stop
         end
       end

--- a/lib/mosql/schema.rb
+++ b/lib/mosql/schema.rb
@@ -316,6 +316,12 @@ module MoSQL
           raise "Invalid null #{source.inspect} for #{pks.inspect}"
         elsif v.is_a? Sequel::SQL::Blob and type != "bytea"
           raise "Failed to convert binary #{source.inspect} to #{type.inspect} for #{pks.inspect}"
+        elsif col[:array_type]
+          v.each_with_index do |e, i|
+            if not sanity_check_type(e, col[:array_type])
+              raise "Failed to convert array element #{i} of #{source.inspect} to #{type.inspect}: got #{e.inspect} for #{pks.inspect}"
+            end
+         end
         elsif not sanity_check_type(v, type)
           raise "Failed to convert #{source.inspect} to #{type.inspect}: got #{v.inspect} for #{pks.inspect}"
         end

--- a/lib/mosql/schema.rb
+++ b/lib/mosql/schema.rb
@@ -250,8 +250,8 @@ module MoSQL
       type = type.downcase
       if (not v.nil? and not v.is_a? Time and type.include? "timestamp") or
           (v.is_a? Time and not type.include? "timestamp") or
-          (v.is_a? Integer and not type.end_with?('int')) or
-          (not v.nil? and not v.is_a? Integer and type.end_with?('int') and v.modulo(1) != 0)
+          (v.is_a? Integer and not type.include?('int') and not type.include?('float')) or
+          (not v.nil? and not v.is_a? Integer and type.include?('int') and v.modulo(1) != 0)
         false
       else
         true

--- a/lib/mosql/schema.rb
+++ b/lib/mosql/schema.rb
@@ -326,17 +326,17 @@ module MoSQL
 
         null_allowed = !col[:notnull] or col.has_key?(:default)
         if v.nil? and not null_allowed
-          raise "Invalid null #{source.inspect} for #{get_pks_for_debug(schema, obj, parent_pks)}"
+          raise "Invalid null #{source.inspect} for #{get_pks_for_debug(schema, original, parent_pks)}"
         elsif v.is_a? Sequel::SQL::Blob and type != "bytea"
-          raise "Failed to convert binary #{source.inspect} to #{type.inspect} for #{get_pks_for_debug(schema, obj, parent_pks)}"
+          raise "Failed to convert binary #{source.inspect} to #{type.inspect} for #{get_pks_for_debug(schema, original, parent_pks)}"
         elsif col[:array_type] and not v.nil?
           v.each_with_index do |e, i|
             if not sanity_check_type(e, col[:array_type])
-              raise "Failed to convert array element #{i} of #{source.inspect} to #{type.inspect}: got #{e.inspect} for #{get_pks_for_debug(schema, obj, parent_pks)}"
+              raise "Failed to convert array element #{i} of #{source.inspect} to #{type.inspect}: got #{e.inspect} for #{get_pks_for_debug(schema, original, parent_pks)}"
             end
          end
         elsif not v.nil? and not sanity_check_type(v, type)
-          raise "Failed to convert #{source.inspect} to #{type.inspect}: got #{v.inspect} for #{get_pks_for_debug(schema, obj, parent_pks)}"
+          raise "Failed to convert #{source.inspect} to #{type.inspect}: got #{v.inspect} for #{get_pks_for_debug(schema, original, parent_pks)}"
         end
         row[name] = v
       end

--- a/lib/mosql/schema.rb
+++ b/lib/mosql/schema.rb
@@ -305,7 +305,7 @@ module MoSQL
       pks = parent_pks.clone
       sql_pks = primary_sql_keys_for_schema(schema)
       schema[:columns].each do |col|
-        break unless sql_pks.include?(col[:name])
+        next unless sql_pks.include?(col[:name])
 
         pks[col[:name]] = bson_dig_dotted(obj, col[:source])
       end
@@ -334,7 +334,7 @@ module MoSQL
           v = transform_value(col, fetch_and_delete_dotted(obj, source))
         end
 
-        obj_description = "#{get_pks_for_debug(schema, original, parent_pks)} of #{qualified_table_name(schema[:meta])}"
+        obj_description = "#{get_pks_for_debug(schema, original, parent_pks)} of #{schema[:meta][:table]}"
         null_allowed = !col[:notnull] or col.has_key?(:default)
         if v.nil? and not null_allowed
           raise "Invalid null #{source.inspect} for #{obj_description}"

--- a/lib/mosql/schema.rb
+++ b/lib/mosql/schema.rb
@@ -451,7 +451,7 @@ module MoSQL
       schema[:subtables].each do |subspec|
         source = subspec[:meta][:source]
         subobjs = bson_dig_dotted(obj, source)
-        break if subobjs.nil?
+        next if subobjs.nil?
 
         subobjs.each do |subobj|
           all_transforms_for_obj(subspec, subobj,new_parent_pks, &block)

--- a/lib/mosql/schema.rb
+++ b/lib/mosql/schema.rb
@@ -248,8 +248,8 @@ module MoSQL
 
     def sanity_check_type(v, type)
       type = type.downcase
-      if (not v.nil? and not v.is_a? Time and type == "timestamp") or
-          (v.is_a? Time and not type == "timestamp") or
+      if (not v.nil? and not v.is_a? Time and type.include? "timestamp") or
+          (v.is_a? Time and not type.include? "timestamp") or
           (v.is_a? Integer and not type.end_with?('int')) or
           (not v.nil? and not v.is_a? Integer and type.end_with?('int') and v.modulo(1) != 0)
         false

--- a/lib/mosql/schema.rb
+++ b/lib/mosql/schema.rb
@@ -25,11 +25,11 @@ module MoSQL
           if ment.keys.length != 1
               raise SchemaError.new("Invalid new configuration entry #{ent.inspect}")
           end
-          col[:name] = ment.keys.first
+          col[:name] = ment.keys.first.to_sym
         elsif ent.is_a?(Hash) && ent.keys.length == 1 && ent.values.first.is_a?(String)
           col = {
             :source => ent.first.first,
-            :name   => ent.first.first,
+            :name   => ent.first.first.to_sym,
             :type   => ent.first.last
           }
         else

--- a/lib/mosql/schema.rb
+++ b/lib/mosql/schema.rb
@@ -259,7 +259,7 @@ module MoSQL
       type = type.downcase
       if (not v.nil? and not v.is_a? Time and type.include? "timestamp") or
           (v.is_a? Time and not type.include? "timestamp") or
-          (v.is_a? Integer and not type.include?('int') and not type.include?('float')) or
+          (v.is_a? Integer and not type.include?('int') and not type.include?('float') and not type.include?("numeric")) or
           (not v.nil? and not v.is_a? Integer and type.include?('int') and v.modulo(1) != 0)
         false
       else

--- a/lib/mosql/schema.rb
+++ b/lib/mosql/schema.rb
@@ -442,7 +442,7 @@ module MoSQL
     def primary_sql_keys_for_schema(schema)
       keys = []
       if schema[:meta][:composite_key]
-        keys = schema[:meta][:composite_key]
+        keys = schema[:meta][:composite_key].map{ |k| k.to_sym }
       else
         keys << schema[:columns].find {|c| c[:source] == '_id'}[:name]
       end

--- a/lib/mosql/schema.rb
+++ b/lib/mosql/schema.rb
@@ -1,4 +1,4 @@
-require 'active_support/inflector'
+Sequel.extension :inflector
 
 module MoSQL
   class SchemaError < StandardError; end;

--- a/lib/mosql/schema.rb
+++ b/lib/mosql/schema.rb
@@ -161,10 +161,10 @@ module MoSQL
                 :on_update => :cascade
             }
           end
-          primary_key primary_keys.keys + parent_pks.keys
+          primary_key parent_pks.keys + primary_keys.keys
         end
 
-        parent_pks = Hash[primary_keys.map { |k, t| [parent_scope_column(meta[:table], k), t] }].merge(parent_pks)
+        parent_pks = parent_pks.merge(Hash[primary_keys.map { |k, t| [parent_scope_column(meta[:table], k), t] }])
         spec[:subtables].each do |subspec|
           create_table(db, subspec, clobber, table_name, parent_pks)
         end

--- a/lib/mosql/sql.rb
+++ b/lib/mosql/sql.rb
@@ -23,7 +23,7 @@ module MoSQL
     end
 
     def table_for_ns(ns)
-      @db[@schema.table_for_ns(ns).intern]
+      @db[@schema.table_for_ns(ns)]
     end
 
     def transform_one_ns(ns, obj)

--- a/lib/mosql/sql.rb
+++ b/lib/mosql/sql.rb
@@ -33,9 +33,9 @@ module MoSQL
     end
 
     def delete_ns(ns, obj)
-      @schema.all_transforms_for_ns(ns, [obj]) do |table, pks, _|
-        table_for_ident(table).where(pks).delete
-      end
+      table = table_for_ident(@schema.primary_table_name_for_ns(ns))
+      pks = @schema.primary_sql_keys_for_ns_obj(ns, obj)
+      table.where(pks).delete
     end
 
     def upsert!(table, table_primary_keys, item)

--- a/lib/mosql/sql.rb
+++ b/lib/mosql/sql.rb
@@ -33,22 +33,13 @@ module MoSQL
     end
 
     def delete_ns(ns, obj)
-      @schema.all_transforms_for_ns(ns, [obj]) do |table, pks, row|
-        query = {}
-        pks.each do |key|
-          raise "No #{primary_sql_keys} found in transform of #{obj.inspect}" if row[key].nil?
-          query[key.to_sym] = row[key]
-        end
-        table_for_ident(table).where(query).delete
+      @schema.all_transforms_for_ns(ns, [obj]) do |table, pks, _|
+        table_for_ident(table).where(pks).delete
       end
     end
 
     def upsert!(table, table_primary_keys, item)
-      query = {}
-      table_primary_keys.each do |key|
-        query[key.to_sym] = item[key]
-      end
-      rows = table.where(query).update(item)
+      rows = table.where(table_primary_keys).update(item)
       if rows == 0
         begin
           table.insert(item)

--- a/lib/mosql/streamer.rb
+++ b/lib/mosql/streamer.rb
@@ -80,12 +80,10 @@ module MoSQL
     def initial_import
       @schema.create_schema(@sql.db, !options[:no_drop_tables])
 
-      unless options[:skip_tail]
-        start_state = {
-          'time' => nil,
-          'position' => @tailer.most_recent_position
-        }
-      end
+      start_state = {
+        'time' => nil,
+        'position' => @tailer.most_recent_position
+      }
 
       dbnames = []
 
@@ -115,7 +113,7 @@ module MoSQL
         end
       end
 
-      tailer.save_state(start_state) unless options[:skip_tail]
+      tailer.save_state(start_state)
     end
 
     def did_truncate; @did_truncate ||= {}; end

--- a/lib/mosql/streamer.rb
+++ b/lib/mosql/streamer.rb
@@ -157,8 +157,8 @@ module MoSQL
               sql_time += upsert_all_batches(batches, ns)
               elapsed = Time.now - start
               log.info("Imported #{count} rows into #{ns} (#{elapsed}s, #{sql_time}s SQL)...")
-              exit(0) if @done
             end
+            exit(0) if @done
           end
         end
       end
@@ -176,10 +176,11 @@ module MoSQL
       end
       tailer.tail(:from => tail_from, :filter => options[:oplog_filter])
       until @done
-        tailer.stream(1000) do |op|
+        tailer.stream(5) do |op|
           handle_op(op)
         end
       end
+      tailer.save_state
     end
 
     def sync_object(ns, selector)

--- a/lib/mosql/streamer.rb
+++ b/lib/mosql/streamer.rb
@@ -158,7 +158,7 @@ module MoSQL
             if count % BATCH == 0
               sql_time += upsert_all_batches(batches, ns)
               elapsed = Time.now - start
-              log.info("Imported #{count} rows into #{collection} (#{elapsed}s, #{sql_time}s SQL)...")
+              log.info("Imported #{count} rows into #{ns} (#{elapsed}s, #{sql_time}s SQL)...")
               exit(0) if @done
             end
           end

--- a/lib/mosql/streamer.rb
+++ b/lib/mosql/streamer.rb
@@ -108,7 +108,7 @@ module MoSQL
         db = @mongo.db(dbname)
         collections = db.collections.select { |c| spec.key?(c.name) }
 
-        Parallel.each(collections, in_threads: 8) do |collection|
+        Parallel.each(collections, in_threads: 4) do |collection|
           ns = "#{dbname}.#{collection.name}"
           import_collection(ns, collection, spec[collection.name][:meta][:filter])
           exit(0) if @done

--- a/lib/mosql/streamer.rb
+++ b/lib/mosql/streamer.rb
@@ -108,7 +108,12 @@ module MoSQL
 
         Parallel.each(collections, in_threads: 4) do |collection|
           ns = "#{dbname}.#{collection.name}"
-          import_collection(ns, collection, spec[collection.name][:meta][:filter])
+          begin
+            import_collection(ns, collection, spec[collection.name][:meta][:filter])
+          rescue Exception => ex
+            log.error("Error importing collection #{ns} - #{ex.message}:\n#{ex.backtrace.join("\n")}")
+            raise Parallel::Kill
+          end
           exit(0) if @done
         end
       end

--- a/lib/mosql/streamer.rb
+++ b/lib/mosql/streamer.rb
@@ -1,4 +1,4 @@
-require 'Parallel'
+require 'parallel'
 
 module MoSQL
   class Streamer

--- a/lib/mosql/streamer.rb
+++ b/lib/mosql/streamer.rb
@@ -112,7 +112,6 @@ module MoSQL
             import_collection(ns, collection, spec[collection.name][:meta][:filter])
           rescue Exception => ex
             log.error("Error importing collection #{ns} - #{ex.message}:\n#{ex.backtrace.join("\n")}")
-            raise Parallel::Kill
           end
           exit(0) if @done
         end

--- a/lib/mosql/streamer.rb
+++ b/lib/mosql/streamer.rb
@@ -49,25 +49,14 @@ module MoSQL
     end
 
     def bulk_upsert(table, ns, items)
-      begin
-        @schema.copy_data(table.db, ns, items)
-      rescue Sequel::DatabaseError => e
-        log.warn("Bulk insert error (#{e}), attempting invidual upserts...")
-        cols = @schema.all_columns(@schema.find_ns(ns))
-        items.each do |it|
-          h = {}
-          cols.zip(it).each { |k,v| h[k] = v }
-          unsafe_handle_exceptions(ns, h) do
-            @sql.upsert!(table, @schema.primary_sql_key_for_ns(ns), h)
-          end
-        end
-      end
+      table.multi_insert(items)
     end
 
     def with_retries(tries=10)
       tries.times do |try|
         begin
           yield
+          break
         rescue Mongo::ConnectionError, Mongo::ConnectionFailure, Mongo::OperationFailure => e
           # Duplicate key error
           raise if e.kind_of?(Mongo::OperationFailure) && [11000, 11001].include?(e.error_code)
@@ -129,13 +118,29 @@ module MoSQL
 
     def did_truncate; @did_truncate ||= {}; end
 
+    def upsert_all_batches(batches, ns)
+      # We use all_table_names_for_ns so we can ensure we write the parent table
+      # before we write the child.
+      sql_time = 0
+      @schema.all_table_names_for_ns(ns).map do |table_name|
+        unless batches[table_name].empty?
+          sql_time += track_time do
+            bulk_upsert(@sql.table_for_ident(table_name), ns,
+                        batches[table_name])
+            batches[table_name].clear
+          end
+        end
+      end
+      sql_time
+    end
+
     def import_collection(ns, collection, filter)
       log.info("Importing for #{ns}...")
       count = 0
-      batch = []
-      table = @sql.table_for_ns(ns)
+      batches = Hash[@schema.all_table_names_for_ns(ns).map { |n| [n, []] }]
+      table = @sql.table_for_ident(@schema.primary_table_name_for_ns(ns))
       unless options[:no_drop_tables] || did_truncate[table.first_source]
-        table.truncate
+        table.truncate :cascade => true
         did_truncate[table.first_source] = true
       end
 
@@ -143,26 +148,22 @@ module MoSQL
       sql_time = 0
       collection.find(filter, :batch_size => BATCH) do |cursor|
         with_retries do
-          cursor.each do |obj|
-            batch << @schema.transform(ns, obj)
+          @schema.all_transforms_for_ns(ns, cursor) do |ident, _, row|
+            table = @sql.table_for_ident(ident)
             count += 1
+            batches[ident] << row
 
-            if batch.length >= BATCH
-              sql_time += track_time do
-                bulk_upsert(table, ns, batch)
-              end
+            if count % BATCH == 0
+              sql_time += upsert_all_batches(batches, ns)
               elapsed = Time.now - start
               log.info("Imported #{count} rows (#{elapsed}s, #{sql_time}s SQL)...")
-              batch.clear
               exit(0) if @done
             end
           end
         end
       end
 
-      unless batch.empty?
-        bulk_upsert(table, ns, batch)
-      end
+      sql_time += upsert_all_batches(batches, ns)
 
       elapsed = Time.now - start
       log.info("Finished import of #{count} rows (#{elapsed}s, #{sql_time}s SQL)...")
@@ -234,22 +235,12 @@ module MoSQL
           log.debug("resync #{ns}: #{selector['_id']} (update was: #{update.inspect})")
           sync_object(ns, selector)
         else
-
           # The update operation replaces the existing object, but
           # preserves its _id field, so grab the _id off of the
           # 'query' field -- it's not guaranteed to be present on the
           # update.
-          primary_sql_keys = @schema.primary_sql_key_for_ns(ns)
-          schema = @schema.find_ns!(ns)
-          keys = {}
-          primary_sql_keys.each do |key|
-            source =  schema[:columns].find {|c| c[:name] == key }[:source]
-            keys[source] = selector[source]
-          end
+          update = @schema.save_all_pks_for_ns(ns, update, selector)
 
-          log.debug("upsert #{ns}: #{keys}")
-
-          update = keys.merge(update)
           unsafe_handle_exceptions(ns, update) do
             @sql.upsert_ns(ns, update)
           end

--- a/lib/mosql/streamer.rb
+++ b/lib/mosql/streamer.rb
@@ -52,7 +52,7 @@ module MoSQL
       begin
         @schema.copy_data(table.db, ns, items)
       rescue Sequel::DatabaseError => e
-        log.debug("Bulk insert error (#{e}), attempting invidual upserts...")
+        log.warn("Bulk insert error (#{e}), attempting invidual upserts...")
         cols = @schema.all_columns(@schema.find_ns(ns))
         items.each do |it|
           h = {}
@@ -163,6 +163,9 @@ module MoSQL
       unless batch.empty?
         bulk_upsert(table, ns, batch)
       end
+
+      elapsed = Time.now - start
+      log.info("Finished import of #{count} rows (#{elapsed}s, #{sql_time}s SQL)...")
     end
 
     def optail

--- a/lib/mosql/version.rb
+++ b/lib/mosql/version.rb
@@ -1,3 +1,3 @@
 module MoSQL
-  VERSION = "0.4.3"
+  VERSION = "0.4.4"
 end

--- a/lib/mosql/version.rb
+++ b/lib/mosql/version.rb
@@ -1,3 +1,3 @@
 module MoSQL
-  VERSION = "0.4.4"
+  VERSION = "0.4.5"
 end

--- a/mosql.gemspec
+++ b/mosql.gemspec
@@ -28,8 +28,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "bson", "~> 1.10"
   gem.add_runtime_dependency "bson_ext", "~> 1.10"
 
-  gem.add_runtime_dependency "activesupport", "4.2.6"
-
   gem.add_development_dependency "minitest"
   gem.add_development_dependency "mocha"
 end

--- a/mosql.gemspec
+++ b/mosql.gemspec
@@ -28,6 +28,8 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "bson", "~> 1.10"
   gem.add_runtime_dependency "bson_ext", "~> 1.10"
 
+  gem.add_runtime_dependency "activesupport", "4.2.6"
+
   gem.add_development_dependency "minitest"
   gem.add_development_dependency "mocha"
 end

--- a/mosql.gemspec
+++ b/mosql.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "rake"
   gem.add_runtime_dependency "log4r"
   gem.add_runtime_dependency "json"
+  gem.add_runtime_dependency "parallel"
 
   gem.add_runtime_dependency "mongoriver", "0.4"
 

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-RUBYLIB=$PWD/lib:$RUBYLIB ./bin/mosql "$@"

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,1 @@
+RUBYLIB=$PWD/lib:$RUBYLIB ./bin/mosql

--- a/run.sh
+++ b/run.sh
@@ -1,1 +1,3 @@
-RUBYLIB=$PWD/lib:$RUBYLIB ./bin/mosql
+#!/bin/bash
+
+RUBYLIB=$PWD/lib:$RUBYLIB ./bin/mosql "$@"

--- a/test/unit/lib/mosql/schema.rb
+++ b/test/unit/lib/mosql/schema.rb
@@ -104,8 +104,8 @@ EOF
   end
 
   it 'Can find the primary key of the SQL table' do
-    assert_equal(['id'], @map.primary_sql_key_for_ns('db.collection'))
-    assert_equal(['_id'], @map.primary_sql_key_for_ns('db.old_conf_syntax'))
+    assert_equal(['id'], @map.primary_sql_keys_for_ns('db.collection'))
+    assert_equal(['_id'], @map.primary_sql_keys_for_ns('db.old_conf_syntax'))
   end
 
   it 'can create a SQL schema' do


### PR DESCRIPTION
_Is this project dead? I see no updates in a few years and all the pull requests are stale. Should I bother fixing the tests in my PR and trying to integrate it?_

## Summary

I'm starting to use mosql to migrate from mongodb with mongoose schemas to postgres. This diff has a number of improvements that were necessary for my migration:
 - Support for foreign keys on nested schemas
 - `ObjectId` is now stored as `bytea`
 - Support for array types
 - Support for `:default`, `:notnull`, etc
 - Better bulk insert support (and perf) via the the use of `Sequel::Database##multi_insert`

## Examples

This corresponds to the following:

```
var ChildrenSchema = new mongoose.Schema({
    name: { type: String }
});

var TestSchema = new mongoose.Schema({
    name: { type: String },
    tags: [{ type: String }],
    balance: { type: Number },
    meta: { type: Object },
    children: [ ChildrenSchema ]
});
```

```
alphaflow:
    test:
        :columns:
        - id:
          :source: _id
          :type: bytea 
          :notnull: true
        - name:
          :source: name
          :type: text
        - tags:
          :source: tags
          :type: text array
        - balance:
          :source: balance
          :type: int
        - meta:
          :source: meta
          :type: jsonb
        :meta:
          :table: test 
          :schema: alphaflow
        :children:
          :meta:
            :table: test_children
            :schema: alphaflow
          :columns:
          - id:
            :source: _id
            :type: bytea not null
          - name:
            :source: name
            :type: text
```

## Testing done

A bunch of manual testing, including on some rather complex schemas.

_Note this diff is not safe to integrate, as it broke most of the unit tests_